### PR TITLE
Simplify stop propagation on modal

### DIFF
--- a/src/update/GlobalMessage.elm
+++ b/src/update/GlobalMessage.elm
@@ -10,12 +10,12 @@ type Msg
     | SModalMsg SkillModal
     | BuildMsg BuildPanel
     | ToggleBuildInfo Int
+    | NoOp
 
 
 type CharacterModal
     = OpenCharacterModal Int
     | CloseCharacterModal
-    | IgnoreCloseCharacterModal
     | UpdateCharacterPicker ( Int, Maybe Character )
     | UpdateBuildWithCharacter ( Int, Character )
 

--- a/src/update/listener/CharacterEventListener.elm
+++ b/src/update/listener/CharacterEventListener.elm
@@ -21,38 +21,7 @@ handle msg model =
             updateOrCreateBuild model value
 
         CloseCharacterModal ->
-            handleDoubleClosure model
-
-        IgnoreCloseCharacterModal ->
-            ignoreClosureInModal model
-
-
-ignoreClosureInModal : Model -> Model
-ignoreClosureInModal model =
-    let
-        oldView =
-            model.view
-
-        newView =
-            { oldView | skipNextClosure = True }
-    in
-    { model | view = newView }
-
-
-handleDoubleClosure : Model -> Model
-handleDoubleClosure model =
-    let
-        oldView =
-            model.view
-
-        dontCloseModal =
-            model.view.skipNextClosure
-    in
-    if dontCloseModal then
-        { model | view = { oldView | skipNextClosure = False } }
-
-    else
-        closeModal model
+            closeModal model
 
 
 openModal : Model -> Int -> Model

--- a/src/view/modal/CharacterModal.elm
+++ b/src/view/modal/CharacterModal.elm
@@ -10,7 +10,8 @@ import GlobalMessage exposing (CharacterModal(..), Msg(..))
 import GlobalModel exposing (..)
 import Html exposing (..)
 import Html.Attributes exposing (..)
-import Html.Events exposing (onClick, onMouseOver)
+import Html.Events exposing (onClick, stopPropagationOn, onMouseOver)
+import Json.Decode as Json
 
 
 modalCharacterPicker : Model -> Html Msg
@@ -29,7 +30,7 @@ modalCharacterPicker model =
         ]
         [ div
             [ class "modal-content"
-            , onClick (CModalMsg IgnoreCloseCharacterModal)
+            , stopPropagationOn "click" (Json.succeed (NoOp, True)) 
             ]
             [ viewCharacterGrid model idx
             , viewSideBar model character


### PR DESCRIPTION
J'ai mis un peu de temps a comprendre comment le stopPropagation marche, mais ça à l'air de fonctionner. J'ai copié ça d'une lib optionelle : 

https://github.com/elm-community/html-extra/blob/master/src/Html/Events/Extra.elm#L233

Le seul truc bizarre est qu'il faut quand même émettre un événement qui fait rien, il ne semble pas y  avoir de moyen de faire sans.